### PR TITLE
Fix Global Styles

### DIFF
--- a/src/nuhxboard.rs
+++ b/src/nuhxboard.rs
@@ -1216,7 +1216,7 @@ impl NuhxBoard {
                     if entry.file_type().unwrap().is_file()
                         && entry.path().extension() == Some(std::ffi::OsStr::new("style"))
                     {
-                        Some(StyleChoice::Custom(
+                        Some(StyleChoice::Global(
                             entry
                                 .path()
                                 .file_stem()


### PR DESCRIPTION
I tried having one of my styles be global for ease of use, and had it be unable to load. 
Found the issue to just be that the Styles loaded for the Global Filepath having StyleChoice::Custom used, which led to a difference in file-path for initial detection and loading.